### PR TITLE
expand python_flavor to python executable

### DIFF
--- a/general/macros.hpc
+++ b/general/macros.hpc
@@ -467,15 +467,15 @@ When this package gets updated it installs the latest version of %name. \
 
 # get the python version specific directory for arch specific files in the HPC
 # directory structure (singlepsec).
-%hpc_python_sitearch %{_hpc_python_sysconfig_path %python_flavor platlib %{?hpc_prefix}}
+%hpc_python_sitearch %{_hpc_python_sysconfig_path %{expand:%__%{python_flavor}} platlib %{?hpc_prefix}}
 
 # same for non-singlespec (using internal %%_hpc_python3)
-%hpc_python_sitearch_no_singlespec %{_hpc_python_sysconfig_path %{?_hpc_python3:/usr/bin/python3}%{!?_hpc_python3:%python_flavor} platlib %{?hpc_prefix}}
+%hpc_python_sitearch_no_singlespec %{_hpc_python_sysconfig_path %{?_hpc_python3:/usr/bin/python3}%{!?_hpc_python3:%{expand:%__%{python_flavor}}} platlib %{?hpc_prefix}}
 
 %_hpc_python_ver() %(%1 -c "import sys as s;print(s.version[:3]);")
 
 # get the (abbreviated) python version used for package and directory names (singlespec).
-%hpc_python_version %{_hpc_python_ver %python_flavor}
+%hpc_python_version %{_hpc_python_ver %{expand:%__%{python_flavor}}}
 
 # %{hpc_python_master_package [-n <package_name>] [-g <group>] [-l][-L][-a]}
 # (singlespec)


### PR DESCRIPTION
This is needed for the new coinstallable python3 flavors. Until last Friday, "python3" was the name of the flavor and of the executable in Tumbleweed. Now "python38" is not the same as "python3" or "python3.8".

See also https://github.com/openSUSE/python-rpm-macros/pull/85