### PR TITLE
Stop storing mtime in gzip headers

### DIFF
--- a/general/macros.hpc
+++ b/general/macros.hpc
@@ -745,7 +745,7 @@ sys.exit(0)" %{1}
        for i in $(ls %{buildroot}%{hpc_mandir}/man${j}/*.${j}* | grep -v ".*\.gz$"); \
        do \
          test -L $i && continue \
-	 gzip $i \
+	 gzip -n $i \
        done; \
      done
 


### PR DESCRIPTION
Stop storing mtime in `gzip` headers
to make package builds bit-reproducible.

Related: https://bugzilla.opensuse.org/show_bug.cgi?id=1047218

Without this patch, our openSUSE:Factory/papi package had variation in `/usr/lib/hpc/papi/7.1.0/share/man/man3/PAPIf_hl_stop.3.gz` and other man-pages at offset 4-7.

This patch was done while working on reproducible builds for openSUSE.